### PR TITLE
Add `playsinline` to IPlayerOptions

### DIFF
--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -60,6 +60,7 @@ namespace Player {
     height?: number;
     loop?: boolean;
     muted?: boolean;
+    playsinline?: boolean;
     preload?: 'auto' | 'metadata' | 'none';
     src?: string;
     width?: number;


### PR DESCRIPTION
This adds the `playsinline` field. This is passed to video.js to play videos inline on mobile devices rather than fullscreen. 